### PR TITLE
Fix referencing errors in 2020-04-10-cryptic.md

### DIFF
--- a/blog/2020-04-10-cryptic.md
+++ b/blog/2020-04-10-cryptic.md
@@ -216,114 +216,160 @@ Artimo, P., Jonnalagedda, M., Arnold, K., Baratin, D., Csardi, G., De
 Castro, E., Duvaud, S., Flegel, V., Fortier, A., Gasteiger, E. and
 Grosdidier, A., 2012. ExPASy: SIB bioinformatics resource portal.
 *Nucleic acids research*, 40(W1), pp.W597-W603.
+[DOI: 10.1093/nar/gks400.]
+(https://www.ncbi.nlm.nih.gov/pubmed/22661580)
 
 Bellamy, W., Takase, M., Yamauchi, K., Wakabayashi, H., Kawase, K. and
 Tomita, M., 1992. Identification of the bactericidal domain of
 lactoferrin. *Biochimica et Biophysica Acta (BBA)-Protein Structure and
-Molecular Enzymology*, 1121(1-2), pp.130-136.
+Molecular Enzymology*, 1121(1-2), pp.130-136. 
+[DOI: 10.1016/0167-4838(92)90346-f.]
+(https://www.ncbi.nlm.nih.gov/pubmed/1599934)
 
 Cunha, N.B., Cobacho, N.B., Viana, J.F., Lima, L.A., Sampaio, K.B.,
 Dohms, S.S., Ferreira, A.C., de la Fuente-Núñez, C., Costa, F.F.,
 Franco, O.L. and Dias, S.C., 2017. The next generation of antimicrobial
 peptides (AMPs) as molecular therapeutic tools for the treatment of
 diseases with social and economic impacts. *Drug discovery today*,
-22(2), pp.234-248.
+22(2), pp.234-248. 
+[DOI: 10.1016/j.drudis.2016.10.017.]
+(https://www.ncbi.nlm.nih.gov/pubmed/27890668)
 
 Dennison, S.R., Wallace, J., Harris, F. and Phoenix, D.A., 2005.
 Amphiphilic α-helical antimicrobial peptides and their
 structure/function relationships. *Protein and peptide letters*, 12(1),
-pp.31-39.
+pp.31-39. 
+[DOI: 10.2174/0929866053406084.]
+(http://www.eurekaselect.com/79084/article)
 
 Dias Santos-Junior, C., Pan, S.,, Zhao, XM., Coelho,LP. MACREL:
 antimicrobial peptide screening in genomes and metagenomes. *bioRxiv*,
-2019.12.17.880385; doi: https://doi.org/10.1101/2019.12.17.880385
+2019.12.17.880385; 
+[DOI: 10.1101/2019.12.17.880385.]
+(https://www.biorxiv.org/content/10.1101/2019.12.17.880385v2)
 
 Do, N., Weindl, G., Grohmann, L., Salwiczek, M., Koksch, B., Korting,
 H.C. and Schäfer‐Korting, M., 2014. Cationic membrane‐active
 peptides–anticancer and antifungal activity as well as penetration into
 human skin. *Experimental dermatology*, 23(5), pp.326-331.
+[DOI: 10.1111/exd.12384.]
+(https://www.ncbi.nlm.nih.gov/pubmed/24661024)
 
 Fesenko, I., Azarkina, R., Kirov, I., Kniazev, A., Filippova, A.,
 Grafskaia, E., Lazarev, V., Zgoda, V., Butenko, I., Bukato, O. and
 Lyapina, I., 2019. Phytohormone treatment induces generation of cryptic
 peptides with antimicrobial activity in the Moss Physcomitrella patens.
 *BMC plant biology,* 19(1), pp.1-16.
+[DOI: 10.1186/s12870-018-1611-z.]
+(https://www.ncbi.nlm.nih.gov/pubmed/30616513)
 
 Gifford, J.L., Hunter, H.N. and Vogel, H.J., 2005. *Lactoferricin.
-Cellular and molecular life sciences*, 62(22), p.2588.
+Cellular and molecular life sciences*, 62(22), p.2588. 
+[DOI: 10.1007/s00018-005-5373-z.]
+(https://www.ncbi.nlm.nih.gov/pubmed/16261252)
 
 Gupta, R. and Srivastava, S., 2014. Antifungal effect of antimicrobial
 peptides (AMPs LR14) derived from Lactobacillus plantarum strain LR/14
 and their applications in prevention of grain spoilage. *Food
 microbiology*, 42, pp.1-7.
+[DOI: 10.1016/j.fm.2014.02.005.]
+(https://www.ncbi.nlm.nih.gov/pubmed/24929709)
 
 Heintz-Buschart, A., May, P., Laczny, C.C., Lebrun, L.A., Bellora, C.,
 Krishna, A., Wampach, L., Schneider, J.G., Hogan, A., De Beaufort, C.
 and Wilmes, P., 2016. Integrated multi-omics of the human gut microbiome
 in a case study of familial type 1 diabetes. *Nature microbiology,*
-2(1), pp.1-13.
+2(1), pp.1-13. 
+[DOI: 10.1038/nmicrobiol.2016.180.]
+(https://www.ncbi.nlm.nih.gov/pubmed/27723761)
 
 Hilchie, A.L., Doucette, C.D., Pinto, D.M., Patrzykat, A., Douglas, S.
 and Hoskin, D.W., 2011. Pleurocidin-family cationic antimicrobial
 peptides are cytolytic for breast carcinoma cells and prevent growth of
 tumor xenografts. *Breast cancer research*, 13(5), p.R102.
+[DOI: 10.1186/bcr3043.]
+(https://www.ncbi.nlm.nih.gov/pubmed/22023734)
 
 Huerta-Cepas, J., Szklarczyk, D., Heller, D., Hernández-Plaza, A.,
 Forslund, S.K., Cook, H., Mende, D.R., Letunic, I., Rattei, T., Jensen,
 L.J. and von Mering, C., 2019. eggNOG 5.0: a hierarchical, functionally
 and phylogenetically annotated orthology resource based on 5090
 organisms and 2502 viruses. *Nucleic acids research*, 47(D1),
-pp.D309-D314.
+pp.D309-D314. 
+[DOI: 10.1093/nar/gky1085.]
+(https://www.ncbi.nlm.nih.gov/pubmed/30418610)
 
 Jiravanichpaisal, P., Lee, S.Y., Kim, Y.A., Andrén, T. and Söderhäll,
 I., 2007. Antibacterial peptides in hemocytes and hematopoietic tissue
 from freshwater crayfish Pacifastacus leniusculus: characterization and
 expression pattern. *Developmental & Comparative Immunology*, 31(5),
-pp.441-455.
+pp.441-455. 
+[DOI: 10.1016/j.dci.2006.08.002.]
+(https://europepmc.org/article/med/17049601)
 
 Kumar, P., Kizhakkedathu, J.N. and Straus, S.K., 2018. Antimicrobial
 peptides: Diversity, mechanism of action and strategies to improve the
 activity and biocompatibility in vivo. *Biomolecules*, 8(1), p.4.
+[DOI: 10.3390/biom8010004.]
+(https://www.ncbi.nlm.nih.gov/pubmed/29351202)
 
 Lázár, V., Martins, A., Spohn, R., Daruka, L., Grézal, G., Fekete, G.,
 Számel, M., Jangir, P.K., Kintses, B., Csörgő, B. and Nyerges, Á., 2018.
 Antibiotic-resistant bacteria show widespread collateral sensitivity to
 antimicrobial peptides. *Nature microbiology*, 3(6), pp.718-731.
+[DOI: 10.1038/s41564-018-0164-0.]
+(https://www.ncbi.nlm.nih.gov/pubmed/29795541)
 
 Lei, J., Sun, L., Huang, S., Zhu, C., Li, P., He, J., Mackey, V., Coy,
 D.H. and He, Q., 2019. The antimicrobial peptides and their potential
 clinical applications. *American journal of translational research*,
 11(7), p.3919.
+[PMCID: PMC6684887.]
+(https://www.ncbi.nlm.nih.gov/pubmed/31396309)
 
 Li, N.N., Li, J.Z., Liu, P., Pranantyo, D., Luo, L., Chen, J.C., Kang,
 E.T., Hu, X.F., Li, C.M. and Xu, L.Q., 2017. An antimicrobial peptide
 with an aggregation-induced emission (AIE) luminogen for studying
 bacterial membrane interactions and antibacterial actions. *Chemical
 Communications*, 53(23), pp.3315-3318.
+[DOI: 10.1039/c6cc09408b.]
+(https://www.ncbi.nlm.nih.gov/pubmed/28078346)
 
 Meher, P.K., Sahu, T.K., Saini, V. and Rao, A.R., 2017. Predicting
 antimicrobial peptides with improved accuracy by incorporating the
 compositional, physico-chemical and structural features into Chou’s
 general PseAAC. *Scientific reports*, 7(1), pp.1-12.
+[DOI: 10.1038/srep42362.]
+(https://www.ncbi.nlm.nih.gov/pubmed/28205576)
 
 Nielsen, H., 2017. Predicting secretory proteins with SignalP. In
 Protein function prediction (pp. 59-73). *Humana Press*, New York, NY.
+[DOI: 10.1007/978-1-4939-7015-5_6.]
+(https://www.ncbi.nlm.nih.gov/pubmed/28451972)
 
 Pirtskhalava M, Gabrielian A, Cruz P, Griggs HL, Squires RB, Hurt DE,
 Grigolava M, Chubinidze M, Gogoladze G, Vishnepolsky B, Alekseev V,
 Rosenthal A, and Tartakovsky M. DBAASP v.2: an Enhanced Database of
 Structure and Antimicrobial/Cytotoxic Activity of Natural and Synthetic
 Peptides. *Nucl. Acids Res*., 2016, 44 (D1), D1104-D1112.
+[DOI: 10.1093/nar/gkv1174.]
+(https://www.ncbi.nlm.nih.gov/pubmed/26578581)
 
 Sharma A., Singla D., Rashid M. and Raghava G.P.S (2014) Designing of
 peptides with desired half-life in intestine-like environment. *BMC
-Bioinformatics* 2014, 15:282
+Bioinformatics* 2014, 15:282.
+[DOI: 10.1186/1471-2105-15-282.]
+(https://bmcbioinformatics.biomedcentral.com/articles/10.1186/1471-2105-15-282)
 
 Vladislav, M., Chernov, Olga, A., Chernova, Alexey, A., Mouzykantov,
 Leonid, L., Lopukhov, Rustam, I., Aminov. (2019) Omics of antimicrobials
 and antimicrobial resistance. *Expert Opinion on Drug Discovery* 14:5,
 pages 455-468.
+[DOI: 10.1080/17460441.2019.1588880.]
+(https://www.tandfonline.com/doi/abs/10.1080/17460441.2019.1588880)
 
 Wang, G., Li, X. and Wang, Z. (2016) APD3: the antimicrobial peptide
 database as a tool for research and education. *Nucleic Acids Research*,
-44 D1087-D1093
+44 D1087-D1093.
+[DOI: 10.1093/nar/gkv1278.]
+(https://www.ncbi.nlm.nih.gov/pubmed/26602694)


### PR DESCRIPTION
Added DOI hyperlinks to the referencing on the blogpost 2020-04-10-cryptic.md